### PR TITLE
Update DNSint.py

### DIFF
--- a/DNSint.py
+++ b/DNSint.py
@@ -860,7 +860,7 @@ def count_spf_lookups(spf_record: str, domain: str, timeout: int, depth: int = 0
     
     lookup_count = 0
     
-    mechanisms = re.findall(r'\b(a|mx|ptr|exists):?([^\s]*)', spf_record, re.IGNORECASE)
+    mechanisms = re.findall(r'(?<!\S)(?:[-~+?])?(a(?!ll)\b|mx\b|ptr\b|exists\b)(?::([^\s]+))?', spf_record, re.IGNORECASE)
     lookup_count += len(mechanisms)
     
     includes = re.findall(r'include:([^\s]+)', spf_record, re.IGNORECASE)


### PR DESCRIPTION
SPF DNS lookup count was counting -all and ~all as separate lookups:

python3 DNSint4.py  easydns.com -m

SPF DNS Lookups:
1. a:ll
2. include:myprivacy.ca
3. a:mta.myprivacy.ca
4. a:ll
5. include:registrarmail.net
6. a:ll
7. include:easymail.ca
8. a:ll
9. include:sendgrid.net
10. a:b.sendgrid.net
11. a:ll
12. include:ab.sendgrid.net
13. a:ll